### PR TITLE
Fix mass-delete bug, harden rabbit consumer

### DIFF
--- a/sc_archive/archive.py
+++ b/sc_archive/archive.py
@@ -219,7 +219,7 @@ def run():
             t.id: t
             for t in session.query(SQLTrack).filter(SQLTrack.user_id == artist.id).all()
         }
-        for track in sc.get_user_tracks(artist.id, limit=1000):
+        for track in sc.get_user_tracks(artist.id, limit=200):
             # remove utc timezone to compare with database track
             track.last_modified = track.last_modified.replace(tzinfo=None)
             if track.id in tracks:

--- a/sc_archive/rabbit.py
+++ b/sc_archive/rabbit.py
@@ -3,7 +3,10 @@ import pika.channel
 
 
 def init_rabbitmq(url: str) -> pika.channel.Channel:
-    conn = pika.BlockingConnection(pika.URLParameters(url))
+    params = pika.URLParameters(url)
+    params.heartbeat = 600
+    params.blocked_connection_timeout = 300
+    conn = pika.BlockingConnection(params)
     channel = conn.channel()
     channel.exchange_declare(
         "errors",

--- a/sc_archive/watcher_webhook.py
+++ b/sc_archive/watcher_webhook.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import pathlib
+import time
 
 import pika
 import pika.channel
+import pika.exceptions
 import pika.spec
 from discord_webhook import DiscordEmbed, DiscordWebhook
 
@@ -172,19 +174,30 @@ def error_callback(
 
 
 def run():
-    # init rabbitmq
-    channel: pika.channel.Channel = init_rabbitmq(config.get("rabbit", "url"))
+    while True:
+        try:
+            channel: pika.channel.Channel = init_rabbitmq(
+                config.get("rabbit", "url")
+            )
 
-    error_queue = channel.queue_declare("errors")
-    artist_queue = channel.queue_declare("artists")
-    track_queue = channel.queue_declare("tracks")
+            channel.queue_declare("errors")
+            channel.queue_declare("artists")
+            channel.queue_declare("tracks")
 
-    channel.queue_bind("artists", "artists", routing_key="#")
-    channel.queue_bind("errors", "errors", routing_key="#")
-    channel.queue_bind("tracks", "tracks", routing_key="#")
+            channel.queue_bind("artists", "artists", routing_key="#")
+            channel.queue_bind("errors", "errors", routing_key="#")
+            channel.queue_bind("tracks", "tracks", routing_key="#")
 
-    channel.basic_consume("artists", artist_callback, auto_ack=True)
-    channel.basic_consume("errors", error_callback, auto_ack=True)
-    channel.basic_consume("tracks", track_callback, auto_ack=True)
+            channel.basic_consume("artists", artist_callback, auto_ack=True)
+            channel.basic_consume("errors", error_callback, auto_ack=True)
+            channel.basic_consume("tracks", track_callback, auto_ack=True)
 
-    channel.start_consuming()
+            channel.start_consuming()
+        except (
+            pika.exceptions.AMQPConnectionError,
+            pika.exceptions.ConnectionClosed,
+            pika.exceptions.StreamLostError,
+            pika.exceptions.ChannelClosed,
+        ):
+            logging.exception("Webhook consumer lost rabbit connection, reconnecting in 5s")
+            time.sleep(5)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sc-archive",
-    version="1.0.7",
+    version="1.0.8",
     packages=find_packages(),
     author="7x11x13",
     install_requires=[


### PR DESCRIPTION
## Summary
- Drop get_user_tracks limit from 1000 to 200; SoundCloud's API now rejects limits above ~200 with 400, which the soundcloud-v2 library silently turns into an empty result. That was causing every followed artist's tracks to be soft-deleted on each run (146144/146669 rows already affected, last delete 2026-01-19).
- Set pika heartbeat to 600s so long scdl downloads don't trip the 60s default and tear down the publisher mid-iteration.
- Wrap watcher_webhook.run() in a reconnect loop so the daemon thread survives rabbit restarts (e.g. the daily docker-volume-backup that stops rabbit) instead of dying with ConnectionClosedByBroker.
- Bump to 1.0.8.

Existing soft-deleted rows will heal automatically once an artist is iterated again — update_track and update_artist already clear .deleted when the row reappears in the API.

## Test plan
- [x] Verified `limit=200` returns the artist's tracks via direct API + soundcloud-v2 inside the running container
- [x] Manually exercised the new download_tracks path against gutprayer (105 tracks now visible)
- [ ] Rebuild + restart `archive` container and confirm: no more "Could not download tracks for X" errors, rabbit reconnects cleanly across simulated rabbit restart, webhook thread stays alive
- [ ] Wait for 03:00 UTC backup cron to fire and confirm Discord notifications still work afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)